### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pycodestyle
 logzero
 chaostoolkit-lib
 requests
+typing


### PR DESCRIPTION
typing is needed to run `chaos`.

When I run `pip install chaostoolkit` in an clean venv I get the following error:
```
chaos --version
...
ImportError: No module named 'typing'
```

After installing `typing` via pip everything works as expected.