### PR TITLE
Set exit code to 1 when experiment fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - a new global flag `chaos --settings <path>` to explicitely specify the
   location of the Chaos Toolkit settings file
 
+## Changed
+
+- by default, the run command will now set the exit code to 1 when the
+  experiment is not successful (interrupted, aborted or failed). This can be
+  bypassed by plugins so they have the opportunity to process the journal as
+  well. In that case, they must set the exit code themselves to play nicely.
+
 ## [0.14.0][] - 2018-04-27
 
 [0.14.0]: https://github.com/chaostoolkit/chaostoolkit/compare/0.13.0...0.14.0

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -115,7 +115,8 @@ def cli(ctx: click.Context, verbose: bool = False,
 @click.argument('path', type=click.Path(exists=True))
 @click.pass_context
 def run(ctx: click.Context, path: str, journal_path: str = "./journal.json",
-        dry: bool = False, no_validation: bool = False) -> Journal:
+        dry: bool = False, no_validation: bool = False,
+        fail_fast: bool = True) -> Journal:
     """Run the experiment given at PATH."""
     experiment = load_experiment(click.format_filename(path))
     settings = load_settings(ctx.obj["settings_path"])
@@ -141,6 +142,13 @@ def run(ctx: click.Context, path: str, journal_path: str = "./journal.json",
         notify(settings, RunFlowEvent.RunCompleted, journal)
     else:
         notify(settings, RunFlowEvent.RunFailed, journal)
+
+        # when set (default) we exit this command immediatly if the execution
+        # failed, was aborted or interrupted
+        # when unset, plugins can continue the processing. In that case, they
+        # are responsible to set the process exit code accordingly.
+        if fail_fast:
+            sys.exit(1)
 
     return journal
 


### PR DESCRIPTION
Closes chaostoolkit/chaostoolkit-lib#45

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>