### PR TITLE
Send RunDeviated event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit/compare/0.15.0...HEAD
 
+### Added
+
+- send a `RunFlowEvent.RunDeviated` event in addition to other events when the
+  steady state deviated after the experimental method [#56][56]
+
+[56]: https://github.com/chaostoolkit/chaostoolkit/issues/56
+
 ## [0.15.0][] - 2018-08-09
 
 [0.15.0]: https://github.com/chaostoolkit/chaostoolkit/compare/0.14.0...0.15.0

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -149,6 +149,9 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
     else:
         notify(settings, RunFlowEvent.RunFailed, journal)
 
+        if journal.get("deviated", False):
+            notify(settings, RunFlowEvent.RunDeviated, journal)
+
         # when set (default) we exit this command immediatly if the execution
         # failed, was aborted or interrupted
         # when unset, plugins can continue the processing. In that case, they


### PR DESCRIPTION
When the experiment has deviated, we notify downstreams for it.

Contributes to #56

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>