### PR TITLE
add missing color to logzero formatter for critical log level

### DIFF
--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -88,7 +88,8 @@ def cli(ctx: click.Context, verbose: bool = False,
     colors = logzero.LogFormatter.DEFAULT_COLORS.copy()
     colors[logging.CRITICAL] = logzero.ForegroundColors.RED
     logzero.formatter(
-        formatter=logzero.LogFormatter(fmt=fmt, datefmt="%Y-%m-%d %H:%M:%S", colors=colors),
+        formatter=logzero.LogFormatter(
+            fmt=fmt, datefmt="%Y-%m-%d %H:%M:%S", colors=colors),
         update_custom_handlers=False)
 
     subcommand = ctx.invoked_subcommand

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -85,8 +85,10 @@ def cli(ctx: click.Context, verbose: bool = False,
             click.format_filename(log_file), mode='a',
             loglevel=logging.DEBUG)
 
+    colors = logzero.LogFormatter.DEFAULT_COLORS.copy()
+    colors[logging.CRITICAL] = logzero.ForegroundColors.RED
     logzero.formatter(
-        formatter=logzero.LogFormatter(fmt=fmt, datefmt="%Y-%m-%d %H:%M:%S"),
+        formatter=logzero.LogFormatter(fmt=fmt, datefmt="%Y-%m-%d %H:%M:%S", colors=colors),
         update_custom_handlers=False)
 
     subcommand = ctx.invoked_subcommand


### PR DESCRIPTION
logzero formatter has no default color for critical log level;
this PR is submitted until logzero merges its PR (https://github.com/metachris/logzero/pull/180)

Another solution _(more concise)_ is to update the default dict within the log formatter class, don't know wich you'd prefer:
`logzero.LogFormatter.DEFAULT_COLORS[logging.CRITICAL] = logzero.ForegroundColors.RED`