### PR TITLE
Introducing Code Of Conduct for Chaos Toolkit

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,70 @@
+# Chaos Toolkit Code Of Conduct
+
+Chaos Toolkit adopts Debian project's Code Of Conduct for it's
+participants and contributors.
+
+## Be respectful
+
+In ChaosToolkit project, inevitably there will be people with whom you
+may disagree, or find it difficult to cooperate. Accept that, but even
+so, remain respectful. Disagreement is no excuse for poor behaviour or
+personal attacks, and a community in which people feel threatened is
+not a healthy community.
+
+## Assume good faith
+
+Chaos Toolkit contributors have many ways of reaching our common goal
+of an open API for Chaos Engineering which may differ from your
+ways. Assume that other people are working towards this goal.
+
+Note that many of our Contributors are from around the globe, not
+native English speakers and may have different cultural backgrounds.
+
+## Be Collaborative
+
+Chaos Toolkit is a large project; there is always more to learn within
+it. It's good to ask for help when you need it. Similarly, offers for
+help should be seen in the context of our shared goal of improving
+Chaos Toolkit.
+
+When you make something for the benefit of the project, be willing to
+explain to others how it works, so that they can build on your work to
+make it even better.
+
+## Try to be concise
+
+Keep in mind that what you write once will be read by hundreds of
+people. Writing a short email means people can understand the
+conversation as efficiently as possible. When a long explanation is
+necessary, consider adding a summary.
+
+Try to bring new arguments to a conversation so that each mail adds
+something unique to the thread, keeping in mind that the rest of the
+thread still contains the other messages with arguments that have
+already been made.
+
+Try to stay on topic, especially in discussions that are already fairly large.
+
+## Be open
+
+Most ways of communication used within Chaos Toolkit allow for public
+and private communication. You should use public methods of
+communication for Chaos Toolkit related messages, unless posting
+something sensitive.
+
+## In case of problems
+
+While this code of conduct should be adhered to by participants, we
+recognize that sometimes people may have a bad day, or be unaware of
+some of the guidelines in this code of conduct. When that happens, you
+may reply to them and point out this code of conduct. Instances of
+otherwise unacceptable behavior may be reported by contacting team at
+contact@chaostoolkit.org. All complaints will be reviewed and
+investigated and will result in a response that is appropriate to the
+circumstances.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the [Debian Code Of Conduct][homepage], version 1.0
+[homepage]: https://www.debian.org/code_of_conduct

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,11 +1,11 @@
 # Chaos Toolkit Code Of Conduct
 
-Chaos Toolkit adopts Debian project's Code Of Conduct for it's
+Chaos Toolkit adopts Debian project's Code Of Conduct for its
 participants and contributors.
 
 ## Be respectful
 
-In ChaosToolkit project, inevitably there will be people with whom you
+In the Chaos Toolkit project, inevitably there will be people with whom you
 may disagree, or find it difficult to cooperate. Accept that, but even
 so, remain respectful. Disagreement is no excuse for poor behaviour or
 personal attacks, and a community in which people feel threatened is


### PR DESCRIPTION
Signed-off by: Pravar Agrawal pravarag@gmail.com

#### What this PR does / why we need it:
Defines Code of Conduct for Chaos Toolkit. Defines a way to express and codify the values defined in it to make Chaos Toolkit more welcoming and open for the community.

#### Checklist
- [x] Added CODE_OF_CONDUCT.md to the project