### PR TITLE
Fix broken tests, check test result against the expection value property

### DIFF
--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -43,4 +43,4 @@ def test_unknown_type():
 
     with pytest.raises(TypeError) as x:
         json.dumps({"d": Dummy()})
-    assert "not JSON serializable" in str(x)
+    assert "not JSON serializable" in str(x.value)


### PR DESCRIPTION
Tests are failing locally and on Travis CI.

This test fails on master with the following output:
```
    def test_unknown_type():
        class Dummy:
            pass

        with pytest.raises(TypeError) as x:
            json.dumps({"d": Dummy()})
>       assert "not JSON serializable" in str(x)
E       AssertionError: assert 'not JSON serializable' in '<ExceptionInfo TypeError tblen=5>'
E        +  where '<ExceptionInfo TypeError tblen=5>' = str(<ExceptionInfo TypeError tblen=5>)
```

Signed-off-by: Simon Lindroos <simj91@gmail.com>