### PR TITLE
Issue #142: Added yaml option for chaos init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,8 @@ docs/site/
 junit-test-results.xml
 experiment.log
 experiment.json
+experiment.yaml
+experiment.yml
 output.png
 chaos-report.json
 discovery.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### Added
 
 - Add critical level color to the logger
+- Add chaos init exports experiment also in yaml format
+
+  ```
+  chaos init --experiment-path prod-experiment.yaml
+  ```
 
 ### Changed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ logzero>=1.5.0
 chaostoolkit-lib>=1.6.0
 requests>=2.21
 python-json-logger>=0.1.11
+PyYAML>=5.1.2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,14 +276,28 @@ def test_notify_init_complete(notify):
         'N',
         'N'])
     runner = CliRunner()
-    disco_path = os.path.join(
-        os.path.dirname(__file__), 'fixtures', 'disco.json')
-    result = runner.invoke(cli, [
-        '--settings', empty_settings_path,
-        'init', '--discovery-path', disco_path], input=inputs)
-    assert result.exit_code == 0
-    assert result.exception is None
 
-    notify.assert_any_call(ANY, InitFlowEvent.InitStarted)
-    notify.assert_any_call(ANY, InitFlowEvent.InitCompleted, ANY)
-    
+    base_path = os.path.dirname(__file__)
+    disco_path = os.path.join(base_path, 'fixtures', 'disco.json')
+    export_path_json = os.path.join(base_path, 'experiment.json')
+    export_path_yaml = os.path.join(base_path, 'experiment.yaml')
+
+    export_paths = [None, export_path_json, export_path_yaml]
+
+    for export_path in export_paths:
+        cli_params = ['--settings', empty_settings_path,
+                      'init', '--discovery-path', disco_path]
+
+        if export_path:
+            cli_params.extend(['--experiment-path', export_path])
+        else:
+            export_path = os.path.join(os.getcwd(), "experiment.json")
+
+        result = runner.invoke(cli, cli_params, input=inputs)
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert os.path.exists(export_path)
+
+        notify.assert_any_call(ANY, InitFlowEvent.InitStarted)
+        notify.assert_any_call(ANY, InitFlowEvent.InitCompleted, ANY)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+import pytest
+from chaostoolkit.cli import is_yaml
+
+
+def test_is_yaml():
+    assert not is_yaml("experiment.json")
+    assert not is_yaml("experiment.JsOn")
+    assert is_yaml("experiment.yaml")
+    assert is_yaml("experiment.yml")
+    assert is_yaml("ExperiMent.YAML")


### PR DESCRIPTION
Issue #142: Added yaml option for chaos init with documentation improvements and assorted unit test

Signed-off-by: Nikola Stjelja <nstjelja@gmail.com>