### PR TITLE
Removes usage of pkg_resource with py3.8 backport importlib_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 * Fixed Dockerfile so the right dependencies are installed at build time
+* Replaced pkg_resource usage with python 3.8 backport importlib_metadata
 
 ## [1.3.0][] - 2019-09-03
 

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
-from datetime import date, datetime
-import decimal
 import io
 import json
-import logging
 import os
-import sys
 from typing import List
 import uuid
 
@@ -22,8 +18,8 @@ from chaoslib.settings import load_settings, CHAOSTOOLKIT_CONFIG_PATH
 from chaoslib.types import Activity, Discovery, Experiment, Journal
 import click
 from click_plugins import with_plugins
+import importlib_metadata
 from logzero import logger
-from pkg_resources import iter_entry_points
 import yaml
 
 from chaostoolkit import __version__, encoder
@@ -392,7 +388,8 @@ def init(ctx: click.Context, discovery_path: str = "./discovery.json",
 
 
 # keep this after the cli group declaration for plugins to override defaults
-with_plugins(iter_entry_points('chaostoolkit.cli_plugins'))(cli)
+with_plugins(
+    importlib_metadata.entry_points().get('chaostoolkit.cli_plugins'))(cli)
 
 
 def is_yaml(experiment_path: str) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ chaostoolkit-lib>=1.6.0
 requests>=2.21
 python-json-logger>=0.1.11
 PyYAML>=5.1.2
+importlib-metadata>=1.2.0; python_version < '3.8'


### PR DESCRIPTION
This PR intends to use the python3.8 importlib_metadata backport, for better package & resources management, with high level API.

Signed-off-by: David Martin <david@chaosiq.io>