### PR TITLE
Improves error message for chaos info command with missing target

### DIFF
--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -167,7 +167,9 @@ def validate(ctx: click.Context, path: str) -> Experiment:
 
 
 @cli.command()
-@click.argument('target')
+@click.argument('target',
+                type=click.Choice(['core', 'settings', 'extensions']),
+                metavar="TARGET")
 @click.pass_context
 def info(ctx: click.Context, target: str):
     """Display information about the Chaos Toolkit environment.


### PR DESCRIPTION
it now indicates the list of possible target values

When running `chaos info` command without any expected arguments this will have an error
Before the message was very succinct ie not indicating what were the targets.
```
$ chaos info
Usage: chaos info [OPTIONS] TARGET
Try "chaos info --help" for help.

Error: Missing argument "TARGET".
```

This PR improves the error message, by indicating the list of possible target values. So that the chaos info would display like
```
$ chaos info 
Usage: chaos info [OPTIONS] TARGET
Try "chaos info --help" for help.

Error: Missing argument "TARGET".  Choose from:
        core,
        settings,
        extensions.
```

Signed-off-by: David Martin <david@chaosiq.io>