### PR TITLE
Run docker image with non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Changed
 
 * Migrates CI/CD from TravisCI to Github Actions
+* [Potentially breaking] Build the Docker image with a non-root user by default (rootless container).
+  This is a potentially breaking change if you created your own docker image
+  using the chaostoolkit/chaostoolkit as a base image.
 
 ## [1.4.1][] - 2020-02-20
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,18 @@ LABEL maintainer="chaostoolkit <contact@chaostoolkit.org>"
 
 RUN apk add --no-cache --virtual build-deps gcc g++ git libffi-dev linux-headers \
         python3-dev musl-dev && \
-    pip install --no-cache-dir  -q -U pip && \
+    pip install --no-cache-dir -q -U pip && \
     pip install --no-cache-dir chaostoolkit && \
     apk del build-deps
+
+RUN addgroup --gid 1001 svc
+RUN adduser --disabled-password --home /home/svc --uid 1001 --ingroup svc svc
+WORKDIR /home/svc
+
+# Any non-zero number will do, and unfortunately a named user will not,
+# as k8s pod securityContext runAsNonRoot can't resolve the user ID:
+# https://github.com/kubernetes/kubernetes/issues/40958
+USER 1001
 
 ENTRYPOINT ["/usr/local/bin/chaos"]
 CMD ["--help"]


### PR DESCRIPTION
Currently, the default user when running the docker image is root.
This is not best practice when creating docker images.

This also creates an issue with the open source Kubernetes operator, that mount by default the settings at `/home/svc/.chaostoolkit/`.  

Signed-off-by: David Martin <david@chaosiq.io>