### PR TITLE
Add --no-verify-tls flag for disabling TLS certificate when using

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit/compare/1.4.1...HEAD
 
+### Added
+* New flag `--no-verify-tls` to `chaos run` and `chaos validate`commands;
+  it disables TLS certificate verification when source is downloaded
+  over a self-signed certificate endpoint.
+
 ### Changed
 
 * Migrates CI/CD from TravisCI to Github Actions

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -90,11 +90,13 @@ def cli(ctx: click.Context, verbose: bool = False,
               help='Run the experiment without executing activities.')
 @click.option('--no-validation', is_flag=True,
               help='Do not validate the experiment before running.')
+@click.option('--no-verify-tls', is_flag=True,
+              help='Do not verify TLS certificate.')
 @click.argument('source')
 @click.pass_context
 def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
         dry: bool = False, no_validation: bool = False,
-        no_exit: bool = False) -> Journal:
+        no_exit: bool = False, no_verify_tls: bool = False) -> Journal:
     """Run the experiment loaded from SOURCE, either a local file or a
        HTTP resource. SOURCE can be formatted as JSON or YAML."""
     settings = load_settings(ctx.obj["settings_path"]) or {}
@@ -104,7 +106,8 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
     load_global_controls(settings)
 
     try:
-        experiment = load_experiment(source, settings)
+        experiment = load_experiment(
+            source, settings, verify_tls=not no_verify_tls)
     except InvalidSource as x:
         logger.error(str(x))
         logger.debug(x)
@@ -145,14 +148,18 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
 
 
 @cli.command()
+@click.option('--no-verify-tls', is_flag=True,
+              help='Do not verify TLS certificate.')
 @click.argument('source')
 @click.pass_context
-def validate(ctx: click.Context, source: str) -> Experiment:
+def validate(ctx: click.Context, source: str,
+             no_verify_tls: bool = False) -> Experiment:
     """Validate the experiment at SOURCE."""
     settings = load_settings(ctx.obj["settings_path"])
 
     try:
-        experiment = load_experiment(source)
+        experiment = load_experiment(
+            source, settings, verify_tls=not no_verify_tls)
     except InvalidSource as x:
         logger.error(str(x))
         logger.debug(x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click>=7.0
 click-plugins>=1.0.4
 logzero>=1.5.0
-chaostoolkit-lib~=1.8.1
+chaostoolkit-lib~=1.9
 requests>=2.21
 python-json-logger>=0.1.11
 PyYAML>=5.1.2


### PR DESCRIPTION
experiments from self-signed endpoint

See related issue on ctk lib https://github.com/chaostoolkit/chaostoolkit-lib/issues/163

Signed-off-by: David Martin <david@chaosiq.io>