### PR TITLE
fix: validate_vars returns nothing, but must return convert_vars result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit/compare/1.9.0...HEAD
 
+### Changed
+
+- Fixed `--var` and `--var-file` arguments parsing by addition of missing return into `validate_vars` function
+
 ## [1.9.0][] - 2021-02-18
 
 [1.9.0]: https://github.com/chaostoolkit/chaostoolkit/compare/1.8.1...1.9.0

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -92,7 +92,7 @@ def validate_vars(ctx: click.Context, param: click.Option,
     value converted to the appropriate type.
     """
     try:
-        convert_vars(value)
+        return convert_vars(value)
     except ValueError as x:
         raise click.BadParameter(str(x))
 


### PR DESCRIPTION
From function docstring:

```
    """
    Process all `--var key=value` and return a dictionnary of them with the
    value converted to the appropriate type.
    """
```

But actually there was no return, therefore whole `--var` and `--var-file` thingy was not working
