### PR TITLE
Changed Link Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The Chaos Toolkit takes experiments defined in a [JSON format][json] description
 
 [json]: https://www.json.org/
 
-![Chaos Toolkit Run Sample](https://github.com/chaosiq/demos/raw/master/openfaas/experiments/switching-gce-nodepool/chaostoolkit-run.gif)
+![Chaos Toolkit Run Sample](https://github.com/chaostoolkit/chaostoolkit/blob/master/assets/chaostoolkit-run.gif)
 
 ## Extending the Chaos Toolkit
 


### PR DESCRIPTION
Changed link address to the .gif now stored at: https://github.com/chaostoolkit/chaostoolkit/blob/master/assets/chaostoolkit-run.gif and hence removing the dependency from the `chaosiq` org

Signed-off-by: Charlie Moon <charlie@chaosiq.io>