### PR TITLE
Fix input names on `close_stale_issues`

### DIFF
--- a/.github/workflows/close_stale_issues.yaml
+++ b/.github/workflows/close_stale_issues.yaml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/stale@v4
         with:
           debug-only: true
-          days-before-issues-stale: 365
+          days-before-issue-stale: 365
           days-before-issue-close: 7
           # For now, don't mark PRs stale and don't close them
           days-before-pr-stale: -1
-          days-before-pr-closed: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
Turns out I'd gotten the variable names wrong for the inputs, this fixes that.§

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
