### PR TITLE
Activate setting issues to Stale on a schedule

### DIFF
--- a/.github/workflows/close_stale_issues.yaml
+++ b/.github/workflows/close_stale_issues.yaml
@@ -1,14 +1,20 @@
 name: Close Stale Issues
 on:
   workflow_dispatch:
+  schedule:
+    # Every Sunday at 00:00
+    - cron: '0 0 * * 0'
 
 jobs:
   close-stale-issues:
+    permissions:
+      issues: write
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/stale@v4
         with:
-          debug-only: true
+          stale-issue-message: 'This Issue has not been active in 365 days. To re-activate this Issue, remove the `Stale` label or comment on it. If not re-activated, this Issue will be closed in 7 days.'
+          close-issue-message: 'This Issue was closed because it was not reactivated after 7 days of being marked `Stale`.'
           days-before-issue-stale: 365
           days-before-issue-close: 7
           # For now, don't mark PRs stale and don't close them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Added
 
-* Add debug version of `.github/workflows/close_stale_issues.yaml`
+* Add `.github/workflows/close_stale_issues.yaml` to mark Issues stale after `365` days
+  Also closes them after `7` days of being `Stale`
 
 ## [1.9.1][] - 2021-05-31
 


### PR DESCRIPTION
This PR enables the workflow `close_stale_issues.yaml`

The Workflow will run on either:

* `workflow_dispatch` (Manual invocations)
* `cron` (Every Sunday at 00:00)

Issues will be marked `Stale` if they have not been active for `365` days.

Issues will be closed if they have not been active for `7` days **after** being marked `Stale`.

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
