### PR TITLE
Bump up Stale Issues actions to 200 from 300

### DIFF
--- a/.github/workflows/close_stale_issues.yaml
+++ b/.github/workflows/close_stale_issues.yaml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
+          operations-per-run: 200
           stale-issue-message: 'This Issue has not been active in 365 days. To re-activate this Issue, remove the `Stale` label or comment on it. If not re-activated, this Issue will be closed in 7 days.'
           close-issue-message: 'This Issue was closed because it was not reactivated after 7 days of being marked `Stale`.'
           days-before-issue-stale: 365


### PR DESCRIPTION
* The Stale action by default runs 30 actions (API calls against GitHub)
* Bumping this to 200 as 30 is quite restrictive
* GitHub limit is 1000 calls per hour per repository so we wont hit this limit

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
