### PR TITLE
Fix issue where PyPi being slow meant Docker images used older versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,11 +42,16 @@ jobs:
     - run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
     - run: echo "Release new docker image with tag ${{ env.RELEASE_VERSION }}"
     - name: Building the Docker image
+      uses: nick-invision/retry@v2.4.0
       env:
         DOCKER_TAG: ${{ env.RELEASE_VERSION }}
-      run: |
-        docker build -t chaostoolkit/chaostoolkit .
-        docker tag chaostoolkit/chaostoolkit:latest chaostoolkit/chaostoolkit:${DOCKER_TAG}
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        command: |
+          docker build --build-arg ctkversion=${DOCKER_TAG} -t chaostoolkit/chaostoolkit .
+          docker tag chaostoolkit/chaostoolkit:latest chaostoolkit/chaostoolkit:${DOCKER_TAG}
+
     - name: Publishing to the Docker repository
       env:
         DOCKER_TAG: ${{ env.RELEASE_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 * Add `.github/workflows/close_stale_issues.yaml` to mark Issues stale after `365` days
   Also closes them after `7` days of being `Stale`
 
+### Changed
+
+* Dockerfile now requires `--build-arg ctkversion=<version>` when building
+* `.github/workflows/release.yaml` now uses a retry step for Docker builds to ensure we dont
+  lose a race condition between PyPi and our build step
+
 ## [1.9.1][] - 2021-05-31
 
 [1.9.1]: https://github.com/chaostoolkit/chaostoolkit/compare/1.9.0...1.9.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM python:3.6-alpine
 
 LABEL maintainer="chaostoolkit <contact@chaostoolkit.org>"
 
+ARG ctkversion
+
 RUN apk add --no-cache --virtual build-deps gcc g++ git libffi-dev linux-headers \
         python3-dev musl-dev && \
     pip install --no-cache-dir -q -U pip setuptools && \
-    pip install --no-cache-dir chaostoolkit && \
+    pip install --no-cache-dir chaostoolkit==${ctkversion} && \
     apk del build-deps
 
 RUN addgroup --gid 1001 svc


### PR DESCRIPTION
This PR aims to fix the issue where Docker images from our release pipeline were installing older
`chaostoolkit` versions than the version the release is for

Closes #230
