### PR TITLE
Fix `reognised` to `recognised`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit/compare/1.9.2...HEAD
 
+### Changed
+
+* Fixed typo in `chaos init` prompt from `reognised` to `recognised`
+
 ## [1.9.2][] - 2021-08-16
 
 [1.9.2]: https://github.com/chaostoolkit/chaostoolkit/compare/1.9.1...1.9.2

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -658,7 +658,7 @@ def add_activities(activities: List[Activity], pool: List[Activity],  #noqa: C90
         click.secho(
             "\nA steady-state probe requires a tolerance value, "
             "within which\n"
-            "your system is in a reognised `normal` state.\n",
+            "your system is in a recognised `normal` state.\n",
             fg="blue")
         tolerance_value = click.prompt(
             s("What is the tolerance for this probe?", fg='green'))


### PR DESCRIPTION
This PR fixes a typo when running `chaos init`

Closes #232 