### PR TITLE
Changed multiple references from `continous` to `continuous`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Changed
 
 * Fixed typo in `chaos init` prompt from `reognised` to `recognised`
+* Changed `--hypothesis-strategy` method `continously` to `continuously`
+* Changed `Schedule` paramater from `continous_hypothesis_frequency` to
+  `continuous_hypothesis_frequency`
+* Changed other minor typos
 
 ## [1.9.2][] - 2021-08-16
 
@@ -20,7 +24,7 @@
 ### Changed
 
 * Dockerfile now requires `--build-arg ctkversion=<version>` when building
-* `.github/workflows/release.yaml` now uses a retry step for Docker builds to ensure we dont
+* `.github/workflows/release.yaml` now uses a retry step for Docker builds to ensure we don't
   lose a race condition between PyPi and our build step
 
 ## [1.9.1][] - 2021-05-31
@@ -104,7 +108,7 @@
 * Add the `--fail-fast` flag to the `run` command. This flag is
   only meaningful with `--hypothesis-strategy=during-method-only|continously`.
   If set, this indicates the experiment should be marked as deviating
-  immediatly. When not provided, the hypothesis runs until the end of the
+  immediately. When not provided, the hypothesis runs until the end of the
   method without terminating the experiment
 
 ### Changed
@@ -250,7 +254,7 @@
 - Allow to declare and load controls from settings so they are globally
   applied to all your runs [chaostoolkit-lib#99][99]
 
-  In your settings file, at `~/.chaostooltkit-lib/settings.yaml` add, for
+  In your settings file, at `~/.chaostoolkit-lib/settings.yaml` add, for
   instance:
 
   ```yaml
@@ -425,7 +429,7 @@
 - You can bypass argument in the init command via empty string [#29][29]
 - Allow to create steady-state hypothesis from init command [#28][28]
 - Allow to set rollbacks from init command [#30][30]
-- Pass command executed to checker for compatbility [#36][36]
+- Pass command executed to checker for compatability [#36][36]
 - Better logging of failed discovery [chaostoolkit-lib#29][29lib]
 - Depending now on chaostoolkit-lib 0.14.0
 

--- a/chaostoolkit/check.py
+++ b/chaostoolkit/check.py
@@ -3,8 +3,9 @@ from logzero import logger
 import requests
 
 from chaostoolkit import __version__
+from chaoslib.types import Strategy
 
-__all__ = ["check_newer_version"]
+__all__ = ["check_newer_version", "check_hypothesis_strategy_spelling"]
 
 LATEST_RELEASE_URL = "https://releases.chaostoolkit.org/latest"
 CHANGELOG_URL = "https://github.com/chaostoolkit/chaostoolkit/blob/master/CHANGELOG.md"  # nopep8
@@ -35,3 +36,16 @@ def check_newer_version(command: str):
                 return latest_version
     except Exception:
         pass
+
+
+def check_hypothesis_strategy_spelling(hypothesis_strategy: str):
+    """
+    Checking for incorrectly spelt commands supported by previous versions of the cli
+    """
+    if hypothesis_strategy == "continously":
+        logger.warning(
+            "\nThe \"--hypothesis-strategy=continously\" command is depreciating "
+            "and will be removed in a future version\n"
+            "Instead, please use \"--hypothesis-strategy=continuously\"")
+        hypothesis_strategy = "continuously"
+    return Strategy.from_string(hypothesis_strategy)

--- a/chaostoolkit/check.py
+++ b/chaostoolkit/check.py
@@ -40,12 +40,13 @@ def check_newer_version(command: str):
 
 def check_hypothesis_strategy_spelling(hypothesis_strategy: str):
     """
-    Checking for incorrectly spelt commands supported by previous versions of the cli
+    Checking for incorrectly spelt commands supported by 
+    previous versions of the cli
     """
     if hypothesis_strategy == "continously":
         logger.warning(
-            "\nThe \"--hypothesis-strategy=continously\" command is depreciating "
-            "and will be removed in a future version\n"
+            "\nThe \"--hypothesis-strategy=continously\" command is "
+            "depreciating and will be removed in a future version\n"
             "Instead, please use \"--hypothesis-strategy=continuously\"")
         hypothesis_strategy = "continuously"
     return Strategy.from_string(hypothesis_strategy)

--- a/chaostoolkit/check.py
+++ b/chaostoolkit/check.py
@@ -40,7 +40,7 @@ def check_newer_version(command: str):
 
 def check_hypothesis_strategy_spelling(hypothesis_strategy: str):
     """
-    Checking for incorrectly spelt commands supported by 
+    Checking for incorrectly spelt commands supported by
     previous versions of the cli
     """
     if hypothesis_strategy == "continously":

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -180,7 +180,7 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
         "runtime", {}).setdefault("rollbacks", {}).setdefault(
             "strategy", rollback_strategy)
     hypothesis_strategy = \
-    check_hypothesis_strategy_spelling(hypothesis_strategy)
+        check_hypothesis_strategy_spelling(hypothesis_strategy)
     schedule = Schedule(
         continuous_hypothesis_frequency=hypothesis_frequency,
         fail_fast=fail_fast)

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -126,7 +126,7 @@ def validate_vars(ctx: click.Context, param: click.Option,
 @click.option('--hypothesis-strategy', default="default",
               type=click.Choice([
                   "default", "before-method-only", "after-method-only",
-                  "during-method-only", "continuously"
+                  "during-method-only", "continuously", "continously"
               ], case_sensitive=True),
               help='Strategy to execute the hypothesis during the run.')
 @click.option('--hypothesis-frequency', default=1.0, type=float,

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -126,15 +126,15 @@ def validate_vars(ctx: click.Context, param: click.Option,
 @click.option('--hypothesis-strategy', default="default",
               type=click.Choice([
                   "default", "before-method-only", "after-method-only",
-                  "during-method-only", "continously"
+                  "during-method-only", "continuously"
               ], case_sensitive=True),
               help='Strategy to execute the hypothesis during the run.')
 @click.option('--hypothesis-frequency', default=1.0, type=float,
               help='Pace at which running the hypothesis. '
                    'Only applies when strategy is either: '
-                   'during-method-only or continously')
+                   'during-method-only or continuously')
 @click.option('--fail-fast', is_flag=True, default=False,
-              help='When running in the during-method-onlyt or continous '
+              help='When running in the during-method-only or continuous '
                    'strategies, indicate the hypothesis can fail the '
                    'experiment as soon as it deviates once. Otherwise, keeps '
                    'running until the end of the experiment.')
@@ -181,7 +181,7 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
             "strategy", rollback_strategy)
     hypothesis_strategy = Strategy.from_string(hypothesis_strategy)
     schedule = Schedule(
-        continous_hypothesis_frequency=hypothesis_frequency,
+        continuous_hypothesis_frequency=hypothesis_frequency,
         fail_fast=fail_fast)
 
     journal = run_experiment(

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -17,8 +17,7 @@ from chaoslib.notification import notify, DiscoverFlowEvent, InitFlowEvent, \
     RunFlowEvent, ValidateFlowEvent
 from chaoslib.settings import load_settings, locate_settings_entry, \
     save_settings, CHAOSTOOLKIT_CONFIG_PATH
-from chaoslib.types import Activity, Discovery, Experiment, Journal, \
-    Schedule, Strategy
+from chaoslib.types import Activity, Discovery, Experiment, Journal, Schedule
 import click
 from click_plugins import with_plugins
 try:
@@ -30,7 +29,7 @@ import yaml
 
 from chaostoolkit import __version__, encoder
 from chaostoolkit.check import check_newer_version, \
-check_hypothesis_strategy_spelling
+    check_hypothesis_strategy_spelling
 from chaostoolkit.logging import configure_logger
 
 
@@ -180,7 +179,8 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
     settings.setdefault(
         "runtime", {}).setdefault("rollbacks", {}).setdefault(
             "strategy", rollback_strategy)
-    hypothesis_strategy = check_hypothesis_strategy_spelling(hypothesis_strategy)
+    hypothesis_strategy = \
+    check_hypothesis_strategy_spelling(hypothesis_strategy)
     schedule = Schedule(
         continuous_hypothesis_frequency=hypothesis_frequency,
         fail_fast=fail_fast)

--- a/chaostoolkit/cli.py
+++ b/chaostoolkit/cli.py
@@ -29,7 +29,8 @@ from logzero import logger
 import yaml
 
 from chaostoolkit import __version__, encoder
-from chaostoolkit.check import check_newer_version
+from chaostoolkit.check import check_newer_version, \
+check_hypothesis_strategy_spelling
 from chaostoolkit.logging import configure_logger
 
 
@@ -179,7 +180,7 @@ def run(ctx: click.Context, source: str, journal_path: str = "./journal.json",
     settings.setdefault(
         "runtime", {}).setdefault("rollbacks", {}).setdefault(
             "strategy", rollback_strategy)
-    hypothesis_strategy = Strategy.from_string(hypothesis_strategy)
+    hypothesis_strategy = check_hypothesis_strategy_spelling(hypothesis_strategy)
     schedule = Schedule(
         continuous_hypothesis_frequency=hypothesis_frequency,
         fail_fast=fail_fast)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -3,9 +3,10 @@ from unittest.mock import patch
 
 import semver
 
-from chaostoolkit import __version__
-from chaostoolkit.check import check_newer_version
 
+from chaostoolkit import __version__
+from chaostoolkit.check import check_newer_version, check_hypothesis_strategy_spelling
+from chaoslib.types import Strategy
 
 class FakeResponse:
     def __init__(self, status=200, url=None, response=None):
@@ -41,3 +42,17 @@ def test_version_is_newer(requests):
 
     latest_version = check_newer_version(command="init")
     assert latest_version == __version__
+
+
+def test_that_correct_continuous_option_is_valid():
+    output = check_hypothesis_strategy_spelling("continuously")
+    assert output == Strategy.CONTINUOUS
+
+@patch("chaostoolkit.check.logger", autospec=True)
+def test_that_incorrect_continuous_option_is_valid(logger):
+    output = check_hypothesis_strategy_spelling("continously")
+    logger.warning.assert_called_once_with(
+        ("\nThe \"--hypothesis-strategy=continously\" command is depreciating "
+        "and will be removed in a future version\n"
+        "Instead, please use \"--hypothesis-strategy=continuously\""))
+    assert output == Strategy.CONTINUOUS


### PR DESCRIPTION
There were many references across multiple repositories that misspelled `continuous` which I have now corrected

Previous PR: https://github.com/chaostoolkit/chaostoolkit/pull/212

Related PRs: https://github.com/chaostoolkit/chaostoolkit-lib/pull/227
                      https://github.com/chaostoolkit/chaostoolkit-documentation/pull/140

Signed-off-by: Charlie Moon <charlie@chaosiq.io>