### PR TITLE
Move from Pylama/Pycodestyle to black, flake8, and isort

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=88

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,54 +1,56 @@
-name: Build
+name: Build, Test, and Lint
 
 on:
   push:
-    branches-ignore: [ gh-pages ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
 jobs:
-  test:
-    runs-on: ubuntu-16.04
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt -r requirements-dev.txt
-    - name: Checking the code syntax
-      run: |
-        pylama chaostoolkit
-    - name: Run tests
-      run: |
-        pip install -e .
-        pytest tests/
-#    - name: Upload coverage to Codecov
-#      uses: codecov/codecov-action@v1
-#      if: success() && (matrix.python-version == '3.5')
-#      with:
-#        file: ./coverage.xml
-#        flags: unittests
-#        name: codecov-umbrella
-#        fail_ci_if_error: true
-
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.6'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-    - name: Build the choastoolkit package
+    - name: Build the chaostoolkit package
       run : |
-        python3 setup.py build
+        make build
+
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+    - name: Install dependencies
+      run: |
+        make install-dev
+    - name: Lint chaostoolkit
+      run: |
+        make lint
+
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        make install-dev
+    - name: Run tests
+      run: |
+        make tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit/compare/1.9.3...HEAD
 
+### Changed
+
+* Switched from pycodestyle/pylama to `black`, `flake8`, `isort`
+* Update CI builds to build, lint, and test
+
 ## [1.9.3][] - 2021-08-24
 
 [1.9.3]: https://github.com/chaostoolkit/chaostoolkit/compare/1.9.2...1.9.3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: install
+install:
+	pip install -r requirements.txt
+
+.PHONY: install-dev
+install-dev: install
+	pip install --upgrade pip setuptools wheel
+	pip install -r requirements-dev.txt
+	python setup.py develop
+
+.PHONY: build
+build:
+	python setup.py build
+
+.PHONY: lint
+lint:
+	flake8 chaostoolkit/ tests/
+	isort --check-only --profile black chaostoolkit/ tests/
+	black --check --diff chaostoolkit/ tests/
+
+.PHONY: format
+format:
+	isort --profile black chaostoolkit/ tests/
+	black chaostoolkit/ tests/
+
+.PHONY: tests
+tests:
+	pytest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Firstly the Chaos Toolkit aims to make it simple and straightforward to run
 experiments against your live system to build confidence in its behavior and learn about
 potential weaknesses.
 
-Following the 
+Following the
 [principles of chaos engineering][principles], the Chaos Toolkit aims to be the easiest way to apply these principles to your own complex, and even sometimes chaotic, systems.
 
 [principles]: http://principlesofchaos.org/
@@ -69,7 +69,7 @@ Whenever a new version is released, just download its copy again.
 
 ## Getting Started
 
-Once you have installed the Chaos Toolkit you can use it through its simple command line tool. The tool's main job is to run your experiment and then 
+Once you have installed the Chaos Toolkit you can use it through its simple command line tool. The tool's main job is to run your experiment and then
 generate a report of the findings from the experiment to then share with your team for discussion.
 
 Running an experiment is as simple as:
@@ -86,13 +86,13 @@ The Chaos Toolkit takes experiments defined in a [JSON format][json] description
 
 ## Extending the Chaos Toolkit
 
-The Chaos Toolkit plays the experiment description that you provide to it. 
+The Chaos Toolkit plays the experiment description that you provide to it.
 Experiments are made up of probes and actions (to vary real-world events during an experiment). We are always looking for community contribution and ideas around
 what probes and actions you might need as you integrate chaos experiments through the Chaos Toolkit, into your own unique context and environment.
 
 If you have an idea for a new set of probes and actions that you'd like to share, please first consider raising a ticket or even joining our community slack to suggest your idea.
 
-In terms of implementation, the [Chaos Toolkit currently supports][extend] probes and actions implemented as Python functions, separate processes or even remote HTTP calls. As long as your extensions conform to the [Chaos Toolkit API][api] you can then specify your own unique extensions in your experiment definitions. 
+In terms of implementation, the [Chaos Toolkit currently supports][extend] probes and actions implemented as Python functions, separate processes or even remote HTTP calls. As long as your extensions conform to the [Chaos Toolkit API][api] you can then specify your own unique extensions in your experiment definitions.
 
 The core implementation of the Chaos Toolkit API can be found in the [chaostoolkit-lib][chaoslib] project.
 
@@ -126,13 +126,14 @@ seeks [discussions][join] and continuous improvement.
 
 [join]: https://join.chaostoolkit.org/
 
-From a code perspective, if you wish to contribute, you will need to run a 
-Python 3.5+ environment. Then, fork this repository and submit a PR. The
-project cares for code readability and checks the code style to match best
-practices defined in [PEP8][pep8]. Please also make sure you provide tests
-whenever you submit a PR so we keep the code reliable.
+From a code perspective, if you wish to contribute, you will need to run a
+Python 3.6+ environment. Please, fork this project, write unit tests to cover
+the proposed changes, implement the changes, ensure they meet the formatting
+standards set out by `black`, `flake8`, and `isort`, and then raise a PR to the
+repository for review
 
-[pep8]: https://pycodestyle.readthedocs.io/en/latest/
+Please refer to the [formatting][#formatting-and-linting] section for more
+information on the formatting standards.
 
 The Chaos Toolkit projects require all contributors must sign a
 [Developer Certificate of Origin][dco] on each commit they would like to merge
@@ -152,13 +153,7 @@ those dependencies.
 
 
 ```console
-$ pip install -r requirements-dev.txt -r requirements.txt
-```
-
-Then, point your environment to this directory:
-
-```console
-$ pip install -e .
+$ make install-dev
 ```
 
 Now, you can edit the files and they will be automatically be seen by your
@@ -169,5 +164,33 @@ environment, even when running from the `chaos` command locally.
 To run the tests for the project execute the following:
 
 ```console
-$ pytest
+$ make tests
 ```
+
+### Formatting and Linting
+
+We use a combination of [`black`][black], [`flake8`][flake8], and [`isort`][isort]
+to both lint and format this repositories code.
+
+[black]: https://github.com/psf/black
+[flake8]: https://github.com/PyCQA/flake8
+[isort]: https://github.com/PyCQA/isort
+
+Before raising a Pull Request, we recommend you run formatting against your
+code with:
+
+```console
+$ make format
+```
+
+This will automatically format any code that doesn't adhere to the formatting
+standards.
+
+As some things are not picked up by the formatting, we also recommend you run:
+
+```console
+$ make lint
+```
+
+To ensure that any unused import statements/strings that are too long, etc.
+are also picked up.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
-pycodestyle
+black
 coverage
+flake8
+isort
 pytest>=6.2
 pytest-cov
 pytest-sugar
 semver
-pylama

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation
     Programming Language :: Python :: Implementation :: CPython
 
@@ -60,7 +61,6 @@ tests_require =
     pytest>=2.8
     pytest-cov
     pytest-sugar
-    pylama
     semver
 
 [options.entry_points]
@@ -81,9 +81,3 @@ addopts =
     --cov-report term-missing:skip-covered
     --cov-report xml
     -p no:warnings
-
-[pylama]
-format = pylint
-
-[pylama:pycodestyle]
-max_line_length = 80


### PR DESCRIPTION
This PR moves us over to black, flake8, and isort whilst also:

* Adding tests for Python 3.9
* Modifying the build workflow to run building, testing, and linting
* Adding a Makefile to abstract away common commands
* Updating the README to specify how to use the new formatting etc.

**Note** - This build will fail due to the linting step (Like with `chaostoolkit-aws`, I will
apply the formatting & linting in a separate PR which will then pass the step)
