### PR TITLE
Fix broken README.md link and make comment about CHANGELOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ seeks [discussions][join] and continuous improvement.
 From a code perspective, if you wish to contribute, you will need to run a
 Python 3.6+ environment. Please, fork this project, write unit tests to cover
 the proposed changes, implement the changes, ensure they meet the formatting
-standards set out by `black`, `flake8`, and `isort`, and then raise a PR to the
-repository for review
+standards set out by `black`, `flake8`, and `isort`, add an entry into
+`CHANGELOG.md`, and then raise a PR to the repository for review
 
-Please refer to the [formatting][#formatting-and-linting] section for more
+Please refer to the [formatting](#formatting-and-linting) section for more
 information on the formatting standards.
 
 The Chaos Toolkit projects require all contributors must sign a


### PR DESCRIPTION
This PR fixes a broken link to the formatting section in the README and
mentions that PRs should include an entry in the CHANGELOG.md.


**Note** This PR won't have an entry in the CHANGELOG as it's just minor
changes that aren't of note.

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
