### PR TITLE
Rearranged `pip install` in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Added `.github/workflows/check_pr.yaml` which checks if a PR has modified the
 CHANGELOG.md and if it changed/added tests
+* Moved `pip install --upgrade pip setuptools wheel` step from `install-dev` to
+`install` in the Makefile
 
 ## [1.9.6][] - 2021-08-26
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: install
 install:
+	pip install --upgrade pip setuptools wheel
 	pip install -r requirements.txt
 
 .PHONY: install-dev
 install-dev: install
-	pip install --upgrade pip setuptools wheel
 	pip install -r requirements-dev.txt
 	python setup.py develop
 


### PR DESCRIPTION
Changed [Makefile](https://github.com/chaostoolkit/chaostoolkit/blob/master/Makefile) in alignment with that of the [ChaosLib](https://github.com/chaostoolkit/chaostoolkit-lib/blob/master/Makefile) repo

Signed-off-by: Charlie Moon <charlie@chaosiq.io>