### PR TITLE
Updated Test Workflow

### DIFF
--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Determine if Tests modified
         id: modified
         run: |
-          py_file_change = FALSE
+          py_file_change=false
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [[ ${changed_file} =~ ^tests\/.*test_.*\.py$ ]];
             then
@@ -32,10 +32,10 @@ jobs:
               exit 0
             elif [[ ${changed_file} =~ ^.*\.py$ ]];
             then
-              py_file_change = TRUE # Python file was modified
+              py_file_change=true # Python file was modified
             fi
           done
-          if [ ${py_file_change} == TRUE];
+          if ${py_file_change};
           then
             echo "::set-output name=MODIFIED::FALSE" # Tests were not modified
             exit 0

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -24,14 +24,23 @@ jobs:
       - name: Determine if Tests modified
         id: modified
         run: |
+          py_file_change = FALSE
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [[ ${changed_file} =~ ^tests\/.*test_.*\.py$ ]];
             then
               echo "::set-output name=MODIFIED::TRUE"; # Tests were modified
               exit 0
+            elif [[ ${changed_file} =~ ^.*\.py$ ]];
+            then
+              py_file_change = TRUE # Python file was modified
             fi
           done
-          echo "::set-output name=MODIFIED::FALSE" # Tests were not modified
+          if [ ${py_file_change} == TRUE];
+          then
+            echo "::set-output name=MODIFIED::FALSE" # Tests were not modified
+            exit 0
+          fi
+          echo "::set-output name=MODIFIED::TRUE" # Tests did not need to be modified
           exit 0
       - name: Comment on PR
         if: ${{ steps.modified.outputs.MODIFIED == 'FALSE' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 CHANGELOG.md and if it changed/added tests
 * Moved `pip install --upgrade pip setuptools wheel` step from `install-dev` to
 `install` in the Makefile
+* Updated `check-pr` workflow to ensure `.py` files have been modified before
+issuing a "Tests Not Modified" warning
 
 ## [1.9.6][] - 2021-08-26
 


### PR DESCRIPTION
When opening an earlier PR, I noticed that the "Tests not modified" warning appeared even though I didn't change any files that required tests. This was because the workflow didn't check if `.py` files had been changed for there to be a need to issue a "Tests not modified" warning. Therefore, I have modified the workflow to check whether `.py` files have been editing before issuing the warning to require tests. 

Signed-off-by: Charlie Moon <charlie@chaosiq.io>