### PR TITLE
Changed `Python` to `Python3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG.md and if it changed/added tests
 `install` in the Makefile
 * Updated `.github/workflows/check_pr.yaml` to check that both `CHANGELOG.md`
 and `chaostoolkit/__init__.py` get updated in line with a new version
+* Updated `Makefile` to specify `python3` instead of `python`
 
 ## [1.9.6][] - 2021-08-26
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ install:
 .PHONY: install-dev
 install-dev: install
 	pip install -r requirements-dev.txt
-	python setup.py develop
+	python3 setup.py develop
 
 .PHONY: build
 build:
-	python setup.py build
+	python3 setup.py build
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Updated Makefile to specify Python 3+ for developing and building to avoid syntax errors caused by recent python updates

Signed-off-by: Charlie Moon <charlie@chaosiq.io>