### PR TITLE
Updating README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Engineering tools may not fit: cloud environments, datacenters, CI/CD, etc.
 Provided you have Python 3.8+ installed, you can install it as follows:
 
 ```console
-$ pip install -U chaostoolkit
+pip install -U chaostoolkit
 ```
 
 ## Getting Started
@@ -55,7 +55,7 @@ Once you have installed the Chaos Toolkit you can use it through its simple comm
 Running an experiment is as simple as:
 
 ```console
-$ chaos run experiment.json
+chaos run experiment.json
 ```
 
 ## Get involved!
@@ -92,10 +92,10 @@ following commands:
 [pdm]: https://pdm-project.org/latest/
 
 ```console
-$ pdm install
-$ pdm run test
-$ pdm run format
-$ pdm run lint
+pdm install
+pdm run test
+pdm run format
+pdm run lint
 ```
 
 The Chaos Toolkit projects require all contributors must sign a


### PR DESCRIPTION
Changes Made
Removed dollar signs ($) from commands to prevent them from being copied when users copy the commands.
Details
Removed all instances of $ before commands in the README.md file to ensure that only the commands themselves are copied without the $ sign.
Reasoning
When users copy commands from the README.md file, it's preferable not to include the dollar signs as they are typically used to denote the command prompt and are not part of the actual commands themselves.
Impact
By making this change, the commands in the README.md file will be more user-friendly and easier to copy-paste without unintentionally including unnecessary characters.