### PR TITLE
fix: addresses issue in settings command - Issue #295

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Make the entrypoint of the default container image to NOT be an absolute path
   to be more adaptable from the Kubernetes operator
 
+### Fixed
+
+* Fixed a bug in `chaos settings` command when the settings file does not exist
+
 ## [1.19.0][] - 2024-02-20
 
 [1.19.0]: https://github.com/chaostoolkit/chaostoolkit/compare/1.18.0...1.19.0

--- a/chaostoolkit/commands/settings.py
+++ b/chaostoolkit/commands/settings.py
@@ -36,7 +36,7 @@ def show_settings(ctx: click.Context, fmt: str = "json"):
     Be aware this will not obfuscate secret data.
     """
     if not os.path.isfile(ctx.obj["settings_path"]):
-        click.abort(
+        ctx.fail(
             "No settings file found at {}".format(ctx.obj["settings_path"])
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,8 +32,8 @@ def test_source_experiment_is_mandatory():
     assert result.exit_code == 2
     assert result.exception
     assert (
-        'Error: Missing argument "SOURCE".' in result.output
-        or "Error: Missing argument 'SOURCE'." in result.output
+            'Error: Missing argument "SOURCE".' in result.output
+            or "Error: Missing argument 'SOURCE'." in result.output
     )
 
 
@@ -791,7 +791,7 @@ def test_use_default_cli_strategies_when_none_provided(log_file):
 
 
 def test_rollbacks_cli_rollback_strategies_can_be_overriden_by_experiment(
-    log_file,
+        log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(
@@ -819,7 +819,7 @@ def test_rollbacks_cli_rollback_strategies_can_be_overriden_by_experiment(
 
 
 def test_rollbacks_cli_rollback_strategies_in_experiment_can_be_overriden_by_cli(
-    log_file,
+        log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(
@@ -849,7 +849,7 @@ def test_rollbacks_cli_rollback_strategies_in_experiment_can_be_overriden_by_cli
 
 
 def test_rollbacks_cli_hypothesis_strategies_can_be_overriden_by_experiment(
-    log_file,
+        log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(
@@ -877,7 +877,7 @@ def test_rollbacks_cli_hypothesis_strategies_can_be_overriden_by_experiment(
 
 
 def test_rollbacks_cli_hypothesis_strategies_in_experiment_can_be_overriden_by_cli(
-    log_file,
+        log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(
@@ -904,3 +904,17 @@ def test_rollbacks_cli_hypothesis_strategies_in_experiment_can_be_overriden_by_c
 
     m = "Runtime strategies: hypothesis - after-method-only / rollbacks - default"
     assert m in log
+
+
+def test_settings_command_file_does_not_exist():
+    missing_settings_file: str = "foo.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--settings", missing_settings_file,
+         "settings", "show",
+         "--format", "json"]
+    )
+
+    assert f"Error: No settings file found at {missing_settings_file}" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,8 +32,8 @@ def test_source_experiment_is_mandatory():
     assert result.exit_code == 2
     assert result.exception
     assert (
-            'Error: Missing argument "SOURCE".' in result.output
-            or "Error: Missing argument 'SOURCE'." in result.output
+        'Error: Missing argument "SOURCE".' in result.output
+        or "Error: Missing argument 'SOURCE'." in result.output
     )
 
 
@@ -791,7 +791,7 @@ def test_use_default_cli_strategies_when_none_provided(log_file):
 
 
 def test_rollbacks_cli_rollback_strategies_can_be_overriden_by_experiment(
-        log_file,
+    log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(
@@ -819,7 +819,7 @@ def test_rollbacks_cli_rollback_strategies_can_be_overriden_by_experiment(
 
 
 def test_rollbacks_cli_rollback_strategies_in_experiment_can_be_overriden_by_cli(
-        log_file,
+    log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(
@@ -849,7 +849,7 @@ def test_rollbacks_cli_rollback_strategies_in_experiment_can_be_overriden_by_cli
 
 
 def test_rollbacks_cli_hypothesis_strategies_can_be_overriden_by_experiment(
-        log_file,
+    log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(
@@ -877,7 +877,7 @@ def test_rollbacks_cli_hypothesis_strategies_can_be_overriden_by_experiment(
 
 
 def test_rollbacks_cli_hypothesis_strategies_in_experiment_can_be_overriden_by_cli(
-        log_file,
+    log_file,
 ):
     runner = CliRunner()
     exp_path = os.path.join(


### PR DESCRIPTION
when a file was not found it would cause an uncaught exception. The code was designed to handle this but was using the wrong method. Also added a test for this. This fixes issue #295