### PR TITLE
chore: fixes issue #286 

### DIFF
--- a/chaostoolkit/commands/info.py
+++ b/chaostoolkit/commands/info.py
@@ -48,7 +48,7 @@ def info(ctx: click.Context, target: str):
                 fmt.format(
                     extension.name,
                     extension.version,
-                    extension.license,
+                    extension.license or "Unknown",
                     summary,
                 )
             )


### PR DESCRIPTION
Extensions may not define a license which results in the python type being None. This commit will default extensions with no license info with a value of 'Unknown'. This approach was discussed in #299

closes issue #286 